### PR TITLE
Escape ! by escaping it with a preceding \

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -11,7 +11,7 @@ function test(mealplans) {
   const todaysMealplan = mealplans.days.find((day) => isToday(day.date));
 
   if (todaysMealplan == undefined) {
-    return "Heute gibt es kein Essen in der Mensa!";
+    return "Heute gibt es kein Essen in der Mensa\\!";
   }
 
   const counters = todaysMealplan.counters.filter((meal) => meal.id !== "info");


### PR DESCRIPTION
! is a reserved character in the MarkdownV2-style of Telegram and must therefore be preceded with \ as described in their document.

From the Telegram API documentation:
Any character with code between 1 and 126 inclusively can be escaped anywhere with a preceding '\' character, in which case it is treated as an ordinary character and not a part of the markup. This implies that '\' character usually must be escaped with a preceding '\' character.

Telegram API documentation:
https://core.telegram.org/bots/api#markdownv2-style

Fixes https://github.com/ikelax/mensa-bot/issues/8