### PR TITLE
Show inline query results for all days

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -7,6 +7,7 @@
     "@std/assert": "jsr:@std/assert@1",
     "grammy": "https://deno.land/x/grammy@v1.33.0/mod.ts",
     "ky": "https://esm.sh/ky",
-    "date-fns": "npm:date-fns"
+    "date-fns": "npm:date-fns",
+    "date-fns/locale/de": "npm:date-fns/locale/de"
   }
 }


### PR DESCRIPTION
So far, only an inline query result for today was shown. Now, for each day provided by the API an inline query result is shown.

The dates are sorted such that dates in the future are at the top of the list in ascending order and dates in the past are at the bottom in descending order.

Also, the replied mealplan contains the date of the mealplan as a title now.

Implements https://github.com/ikelax/mensa-bot/issues/7