### PR TITLE
Add more options when receiving private messages

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,18 +1,42 @@
-import { Bot, InlineQueryResultBuilder } from "grammy";
+import { Bot, InlineKeyboard, InlineQueryResultBuilder } from "grammy";
 import {
   fetchMealplans,
   formatMealplan,
+  getMealplanOnDate,
   getMealplanTitle,
-  getTodaysMealplan,
   sortMealplans,
 } from "./mealplans.js";
+import { formatDate } from "./formatDate.js";
 
 export { getMensaBot };
 
-async function replyWithTodaysMealplan(ctx) {
+function getInlineKeyboard(mealplans) {
+  const labelDataPairs = mealplans.days.map((
+    day,
+  ) => [formatDate(day.date), day.date]);
+  const buttonRow = labelDataPairs
+    .map(([label, data]) => InlineKeyboard.text(label, data));
+  return InlineKeyboard.from([buttonRow]).toTransposed();
+}
+
+async function replyWithMealplanOnDate(ctx, date) {
   const mealplans = await fetchMealplans();
-  const todaysMealplan = getTodaysMealplan(mealplans);
-  ctx.reply(todaysMealplan, { parse_mode: "MarkdownV2" });
+  const todaysMealplan = getMealplanOnDate(
+    mealplans,
+    date,
+    "Heute gibt es kein Essen in der Mensa\\!",
+  );
+  ctx.reply(todaysMealplan, {
+    parse_mode: "MarkdownV2",
+  });
+}
+
+async function replyWithListOfMealplanDates(ctx) {
+  const mealplans = await fetchMealplans();
+  const inlineKeyboard = getInlineKeyboard(mealplans);
+  ctx.reply("Choose a mealplan.", {
+    reply_markup: inlineKeyboard,
+  });
 }
 
 async function getInlineQueryResults() {
@@ -36,11 +60,24 @@ async function getInlineQueryResults() {
 function getMensaBot(token) {
   const bot = new Bot(token);
 
-  bot.command("start", (ctx) => ctx.reply("Welcome! Up and running."));
+  bot.command(
+    "start",
+    (ctx) =>
+      ctx.reply("Welcome! Up and running."),
+  );
+  bot.command(
+    ["days", "d", "m", "mealplans", "meals", "menus"],
+    (ctx) =>
+      replyWithListOfMealplanDates(ctx)
+  );
   bot.on(
     "message",
-    (ctx) => replyWithTodaysMealplan(ctx),
+    (ctx) => replyWithMealplanOnDate(ctx, Date.now()),
   );
+  bot.on("callback_query:data", async (ctx) => {
+    replyWithMealplanOnDate(ctx, ctx.callbackQuery.data);
+    await ctx.answerCallbackQuery();
+  });
   bot.on("inline_query", async (ctx) => {
     await ctx.answerInlineQuery(await getInlineQueryResults(), {
       cache_time: 0,

--- a/bot.js
+++ b/bot.js
@@ -19,14 +19,14 @@ function getInlineKeyboard(mealplans) {
   return InlineKeyboard.from([buttonRow]).toTransposed();
 }
 
-async function replyWithMealplanOnDate(ctx, date) {
+async function replyWithMealplanOnDate(ctx, date, messageIfNoMealplanIsFound) {
   const mealplans = await fetchMealplans();
-  const todaysMealplan = getMealplanOnDate(
+  const mealplanOnDate = getMealplanOnDate(
     mealplans,
     date,
-    "Heute gibt es kein Essen in der Mensa\\!",
+    messageIfNoMealplanIsFound,
   );
-  ctx.reply(todaysMealplan, {
+  ctx.reply(mealplanOnDate, {
     parse_mode: "MarkdownV2",
   });
 }
@@ -62,20 +62,27 @@ function getMensaBot(token) {
 
   bot.command(
     "start",
-    (ctx) =>
-      ctx.reply("Welcome! Up and running."),
+    (ctx) => ctx.reply("Welcome! Up and running."),
   );
   bot.command(
     ["days", "d", "m", "mealplans", "meals", "menus"],
-    (ctx) =>
-      replyWithListOfMealplanDates(ctx)
+    (ctx) => replyWithListOfMealplanDates(ctx),
   );
   bot.on(
     "message",
-    (ctx) => replyWithMealplanOnDate(ctx, Date.now()),
+    (ctx) =>
+      replyWithMealplanOnDate(
+        ctx,
+        Date.now(),
+        "Heute gibt es kein Essen in der Mensa\\!",
+      ),
   );
   bot.on("callback_query:data", async (ctx) => {
-    replyWithMealplanOnDate(ctx, ctx.callbackQuery.data);
+    replyWithMealplanOnDate(
+      ctx,
+      ctx.callbackQuery.data,
+      "An dem Tag gibt es kein Essen in der Mensa\\!",
+    );
     await ctx.answerCallbackQuery();
   });
   bot.on("inline_query", async (ctx) => {

--- a/formatDate.js
+++ b/formatDate.js
@@ -1,0 +1,18 @@
+import { format } from "date-fns";
+import { de } from "date-fns/locale";
+
+export { formatDate };
+
+/**
+ * Formats the date like "Freitag, 27.12.2024".
+ *
+ * @param {string} timestamp the timestamp of the date
+ * @returns {string} the formatted date
+ */
+function formatDate(timestamp) {
+  const dateFnsOptions = { locale: de };
+  const weekday = format(timestamp, "EEEE", dateFnsOptions);
+  const date = format(timestamp, "P", dateFnsOptions);
+
+  return `${weekday}, ${date}`;
+}

--- a/mealplans.js
+++ b/mealplans.js
@@ -1,4 +1,4 @@
-import { isToday, isPast, isSameDay } from "date-fns";
+import { isPast, isSameDay, isToday } from "date-fns";
 import ky from "ky";
 import { formatDate } from "./formatDate.js";
 
@@ -35,7 +35,6 @@ async function fetchMealplans() {
 function getMealplanOnDate(mealplans, timestamp, defaultMessage) {
   const mealplan = findMealplanOnDate(mealplans, timestamp);
 
-  //
   if (mealplan == undefined) {
     return defaultMessage + "\n\n" + linkToMealplan;
   }

--- a/mealplans.js
+++ b/mealplans.js
@@ -1,17 +1,16 @@
-import { format, isPast, isToday } from "date-fns";
-import { de } from "date-fns/locale";
+import { isToday, isPast, isSameDay } from "date-fns";
 import ky from "ky";
+import { formatDate } from "./formatDate.js";
 
 export {
   fetchMealplans,
   formatMealplan,
+  getMealplanOnDate,
   getMealplanTitle,
-  getTodaysMealplan,
   sortMealplans,
 };
 
 const linkToMealplan = "[Speiseplan](https://mensaar.de/#/menu/sb)";
-const dateFnsOptions = { locale: de };
 
 /**
  * Fetches the mealplans from the Mensaar page.
@@ -24,22 +23,24 @@ async function fetchMealplans() {
 }
 
 /**
- * Finds the mealplan for today and returns it formatted in Markdown.
- * If it does not find a mealplan for today, it returns a message
- * indicating this.
+ * Finds the mealplan on a specific date and returns it formatted in Markdown.
+ * If it does not find a mealplan on the date, it returns the `defaultMessage`
+ * with a link to the mealplan.
  *
  * @param {*} mealplans an object with mealplans
- * @returns {string} the mealplan for today or the message that there is
- * no food today
+ * @param {number} timestamp the timestamp of the date
+ * @param {string} defaultMessage the default message in case no mealplan is found
+ * @returns {string} the mealplan for the date or the default message if no mealplan is found
  */
-function getTodaysMealplan(mealplans) {
-  const todaysMealplan = findTodaysMealplan(mealplans);
+function getMealplanOnDate(mealplans, timestamp, defaultMessage) {
+  const mealplan = findMealplanOnDate(mealplans, timestamp);
 
-  if (todaysMealplan == undefined) {
-    return "Heute gibt es kein Essen in der Mensa\\!\n\n" + linkToMealplan;
+  //
+  if (mealplan == undefined) {
+    return defaultMessage + "\n\n" + linkToMealplan;
   }
 
-  return formatMealplan(todaysMealplan);
+  return formatMealplan(mealplan);
 }
 
 /**
@@ -127,13 +128,14 @@ function sortMealplans(mealplans) {
 }
 
 /**
- * Searches for todays mealplan in the mealplans object.
+ * Searches for a mealplan on a specific date in the mealplans object.
  *
  * @param {*} mealplans the mealplans to search
- * @returns {object | undefined} todays mealplan or undefined if it did not find the mealplan
+ * @param {number} timestamp the timestamp of the date
+ * @returns {object | undefined} the mealplan for the date or undefined if it did not find the mealplan
  */
-function findTodaysMealplan(mealplans) {
-  return mealplans.days.find((day) => isToday(day.date));
+function findMealplanOnDate(mealplans, timestamp) {
+  return mealplans.days.find((day) => isSameDay(day.date, timestamp));
 }
 
 /**
@@ -150,16 +152,15 @@ function findTodaysMealplan(mealplans) {
  * @returns {string} the title of the mealplan
  */
 function getMealplanTitle(timestamp) {
-  const weekday = format(timestamp, "EEEE", dateFnsOptions);
-  const date = format(timestamp, "P", dateFnsOptions);
+  const date = formatDate(timestamp);
 
   if (isToday(timestamp)) {
-    return `${weekday}, ${date} (heute)`;
+    return `${date} (heute)`;
   }
 
   if (isPast(timestamp)) {
-    return `${weekday}, ${date} (vergangen)`;
+    return `${date} (vergangen)`;
   }
 
-  return `${weekday}, ${date}`;
+  return date;
 }


### PR DESCRIPTION
A command was added which returns all days with a mealplan as inline keyboard. When a user clicks on a button of this inline keyboard, the bot replies with the mealplan for this date.

Closes https://github.com/ikelax/mensa-bot/issues/9