### PR TITLE
Add commands for tomorrow's meal plan

### DIFF
--- a/MANUAL_TESTS.md
+++ b/MANUAL_TESTS.md
@@ -4,11 +4,13 @@ Because the unit tests do not cover the Telegram based functionality,
 the following manual tests should be done if (large) changes to the
 codebase are made.
 
-| Action                                                             | Expected result                                                      |
-| ------------------------------------------------------------------ | -------------------------------------------------------------------- |
-| Make an inline query `@mensa_sbot` and click on one of the results | Replies with the meals for the chosen day.                           |
-| View the available days in an inline query.                        | They are the same as on [Mensaar](https://mensaar.de/#/menu/sb).     |
-| Send `/start`.                                                     | Replies with the welcome message.                                    |
-| Send `/days`, `/d`, `/m`, `/mealplans`, `/meals` or `/menus`.      | Replies with a list of inline buttons with the days in the meal plan |
-| Click on an inline button.                                         | Replies with the meals for the chosen day.                           |
-| View the available days in list of inline buttons.                 | They are the same as on [Mensaar](https://mensaar.de/#/menu/sb).     |
+| Action                                                             | Expected result                                                       |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| Make an inline query `@mensa_sbot` and click on one of the results | Replies with the meals for the chosen day.                            |
+| View the available days in an inline query.                        | They are the same as on [Mensaar](https://mensaar.de/#/menu/sb).      |
+| Send `/start`.                                                     | Replies with the welcome message.                                     |
+| Send `/days`, `/d`, `/m`, `/mealplans`, `/meals` or `/menus`.      | Replies with a list of inline buttons with the days in the meal plan. |
+| Click on an inline button.                                         | Replies with the meals for the chosen day.                            |
+| View the available days in list of inline buttons.                 | They are the same as on [Mensaar](https://mensaar.de/#/menu/sb).      |
+| Send `/t` or `/tomorrow`.                                          | Replies with tomorrow's meal plan.                                    |
+| Send a message.                                                    | Replies with today's meal plan.                                       |

--- a/bot.js
+++ b/bot.js
@@ -7,6 +7,7 @@ import {
   sortMealplans,
 } from "./mealplans.js";
 import { formatDate } from "./formatDate.js";
+import { addDays } from "date-fns";
 
 export { getMensaBot };
 
@@ -62,6 +63,13 @@ function getMensaBot(token) {
   bot.command("start", (ctx) => ctx.reply("Welcome! Up and running."));
   bot.command(["days", "d", "m", "mealplans", "meals", "menus"], (ctx) =>
     replyWithListOfMealplanDates(ctx),
+  );
+  bot.command(["t", "tomorrow"], (ctx) =>
+    replyWithMealplanOnDate(
+      ctx,
+      addDays(Date.now(), 1),
+      "Morgen gibt es kein Essen in der Mensa\\!",
+    ),
   );
   bot.on("message", (ctx) =>
     replyWithMealplanOnDate(


### PR DESCRIPTION
The bot sends tomorrow's meal plan for the commands `/t` and `/tomorrow`.

Closes https://github.com/ikelax/mensa-bot/issues/38